### PR TITLE
8.0.0 — PHP 8.3+ floor & lock-step major

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,12 +15,15 @@ permissions:
   contents: read
 
 on:
+  schedule:
+    - cron: '0 4 * * *'   # daily 04:00 UTC canary keepalive
   pull_request:
     branches:
       - "*"
   push:
     branches:
       - 'master'
+  workflow_dispatch: {}
 
 env:
   COLUMNS: 120
@@ -34,12 +37,12 @@ jobs:
       JBZOO_COMPOSER_UPDATE_FLAGS: ${{ matrix.composer_flags }}
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
         coverage: [ xdebug, none ]
         composer_flags: [ "--prefer-lowest", "" ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -58,18 +61,19 @@ jobs:
         run: make test --no-print-directory
 
       - name: Uploading coverage to coveralls
-        if: ${{ matrix.coverage == 'xdebug' }}
+        if: '${{ matrix.coverage == ''xdebug'' }}'
         continue-on-error: true
         env:
-          COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            COVERALLS_REPO_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: make report-coveralls --no-print-directory || true
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: PHPUnit - ${{ matrix.php-version }} - ${{ matrix.coverage }}
           path: build/
+          overwrite: true
 
 
   linters:
@@ -77,10 +81,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -99,11 +103,12 @@ jobs:
         run: make codestyle --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Linters - ${{ matrix.php-version }}
           path: build/
+          overwrite: true
 
 
   report:
@@ -111,10 +116,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [ 8.2, 8.3, 8.4 ]
+        php-version: [ 8.3, 8.4, 8.5 ]
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
@@ -133,8 +138,9 @@ jobs:
         run: make report-all --no-print-directory
 
       - name: Upload Artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         continue-on-error: true
         with:
           name: Reports - ${{ matrix.php-version }}
           path: build/
+          overwrite: true

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ Test resources include LESS files, expected CSS outputs, and assets (images) for
 
 ## Key Dependencies
 
-- **PHP 8.2+** requirement
+- **PHP 8.3+** requirement
 - **wikimedia/less.php** (>=5.4.0) - Core LESS compiler
 - **JBZoo ecosystem**:
   - `jbzoo/data` - Configuration data handling

--- a/README.md
+++ b/README.md
@@ -1,7 +1,15 @@
 # JBZoo / Less
 
-[![CI](https://github.com/JBZoo/Less/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Less/actions/workflows/main.yml?query=branch%3Amaster)    [![Coverage Status](https://coveralls.io/repos/github/JBZoo/Less/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Less?branch=master)    [![Psalm Coverage](https://shepherd.dev/github/JBZoo/Less/coverage.svg)](https://shepherd.dev/github/JBZoo/Less)    [![Psalm Level](https://shepherd.dev/github/JBZoo/Less/level.svg)](https://shepherd.dev/github/JBZoo/Less)    [![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/less/badge)](https://www.codefactor.io/repository/github/jbzoo/less/issues)
-[![Stable Version](https://poser.pugx.org/jbzoo/less/version)](https://packagist.org/packages/jbzoo/less/)    [![Total Downloads](https://poser.pugx.org/jbzoo/less/downloads)](https://packagist.org/packages/jbzoo/less/stats)    [![Dependents](https://poser.pugx.org/jbzoo/less/dependents)](https://packagist.org/packages/jbzoo/less/dependents?order_by=downloads)    [![GitHub License](https://img.shields.io/github/license/jbzoo/less)](https://github.com/JBZoo/Less/blob/master/LICENSE)
+[![CI](https://github.com/JBZoo/Less/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/JBZoo/Less/actions/workflows/main.yml?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/JBZoo/Less/badge.svg?branch=master)](https://coveralls.io/github/JBZoo/Less?branch=master)
+[![Psalm Coverage](https://shepherd.dev/github/JBZoo/Less/coverage.svg)](https://shepherd.dev/github/JBZoo/Less)
+[![Psalm Level](https://shepherd.dev/github/JBZoo/Less/level.svg)](https://shepherd.dev/github/JBZoo/Less)
+[![CodeFactor](https://www.codefactor.io/repository/github/jbzoo/less/badge)](https://www.codefactor.io/repository/github/jbzoo/less/issues)
+
+[![Stable Version](https://poser.pugx.org/jbzoo/less/version)](https://packagist.org/packages/jbzoo/less/)
+[![Total Downloads](https://poser.pugx.org/jbzoo/less/downloads)](https://packagist.org/packages/jbzoo/less/stats)
+[![Dependents](https://poser.pugx.org/jbzoo/less/dependents)](https://packagist.org/packages/jbzoo/less/dependents?order_by=downloads)
+[![GitHub License](https://img.shields.io/github/license/jbzoo/less)](https://github.com/JBZoo/Less/blob/master/LICENSE)
 
 
 A powerful PHP wrapper for [wikimedia/less.php](https://github.com/wikimedia/less.php) that provides enhanced LESS compilation with caching, advanced configuration options, and streamlined error handling.
@@ -19,7 +27,7 @@ A powerful PHP wrapper for [wikimedia/less.php](https://github.com/wikimedia/les
 
 ## Requirements
 
-- PHP 8.2 or higher
+- PHP 8.3 or higher
 - Composer
 
 ## Installation

--- a/composer.json
+++ b/composer.json
@@ -29,15 +29,15 @@
     "prefer-stable"     : true,
 
     "require"           : {
-        "php"                : "^8.2",
+        "php"                : "^8.3",
 
-        "jbzoo/data"         : "^7.2",
-        "jbzoo/utils"        : "^7.3",
+        "jbzoo/data"         : "^8.0",
+        "jbzoo/utils"        : "^8.0",
         "wikimedia/less.php" : ">=5.4.0"
     },
 
     "require-dev"       : {
-        "jbzoo/toolbox-dev" : "^7.2"
+        "jbzoo/toolbox-dev" : "^8.0"
     },
 
     "autoload"          : {
@@ -55,7 +55,7 @@
 
     "extra"             : {
         "branch-alias" : {
-            "dev-master" : "7.x-dev"
+            "dev-master" : "8.x-dev"
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -10,25 +10,14 @@
     @copyright  Copyright (C) JBZoo.com, All rights reserved.
     @see        https://github.com/JBZoo/Less
 -->
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         bootstrap="tests/autoload.php"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         convertDeprecationsToExceptions="true"
-         executionOrder="random"
+<phpunit bootstrap="tests/autoload.php"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
          stopOnIncomplete="false"
          stopOnSkipped="false"
-         stopOnRisky="false"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
->
-    <coverage processUncoveredFiles="true">
-        <include>
-            <directory suffix=".php">src</directory>
-        </include>
+         stopOnRisky="false">
+    <coverage>
         <report>
             <clover outputFile="build/coverage_xml/main.xml"/>
             <php outputFile="build/coverage_cov/main.cov"/>
@@ -39,10 +28,17 @@
     <testsuites>
         <testsuite name="All">
             <directory suffix="Test.php">tests</directory>
+            <exclude>tests/AbstractLessTest.php</exclude>
         </testsuite>
     </testsuites>
 
     <logging>
         <junit outputFile="build/coverage_junit/main.xml"/>
     </logging>
+
+    <source>
+        <include>
+            <directory suffix=".php">src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/src/Less.php
+++ b/src/Less.php
@@ -30,6 +30,20 @@ final class Less
     private Data   $options;
     private Gpeasy $driver;
 
+    /**
+     * @var array{
+     *     force: bool,
+     *     debug: bool,
+     *     root_url: ?string,
+     *     root_path: ?string,
+     *     global_vars: array,
+     *     autoload: array,
+     *     import_paths: array,
+     *     functions: array,
+     *     cache_path: string,
+     *     cache_ttl: int,
+     * }
+     */
     private array $default = [
         'force'        => false,
         'debug'        => false, // On/Off Source map for browser debug console


### PR DESCRIPTION
Coordinated ecosystem-wide **8.0** major (packaging-driven; no public API change).

- Minimum PHP raised to **8.3** (CI: 8.3 / 8.4 / 8.5).
- All inter-package `jbzoo/*` deps → `^8.0`.
